### PR TITLE
feat: implement UC14 grocery list feature: Product price 

### DIFF
--- a/Grocery.App/MauiProgram.cs
+++ b/Grocery.App/MauiProgram.cs
@@ -19,8 +19,6 @@ namespace Grocery.App
                 .UseMauiCommunityToolkit()
                 .ConfigureFonts(fonts =>
                 {
-                    fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
-                    fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
                 });
 
 #if DEBUG

--- a/Grocery.App/Views/ProductView.xaml
+++ b/Grocery.App/Views/ProductView.xaml
@@ -1,10 +1,11 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
+
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:Grocery.App.ViewModels"
              x:Class="Grocery.App.Views.ProductView"
              Title="ProductView">
-    
+
     <Shell.TitleView>
         <Grid>
             <Label Text="Producten" FontSize="Large" HorizontalOptions="Center" VerticalOptions="Center" />
@@ -12,42 +13,51 @@
     </Shell.TitleView>
 
     <Border Stroke="#C49B33" StrokeThickness="4" Padding="10" Margin="10" HorizontalOptions="Center">
-        <CollectionView ItemsSource="{Binding Products}" Margin="20" HorizontalOptions="Center">
-            <CollectionView.ItemsLayout>
-                <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
-            </CollectionView.ItemsLayout>
-            <CollectionView.Header>
-                <Grid>
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="3*"/>
-                        <ColumnDefinition Width="2*"/>
-                        <ColumnDefinition Width="*"/>
-                    </Grid.ColumnDefinitions>
-                    <Label Text="Naam van het product" Grid.Column="0" FontAttributes="Bold"/>
-                    <Label Text="Voorraad" Grid.Column="1" HorizontalTextAlignment="End" FontAttributes="Bold"/>
-                    <Label Text="THT datum" Grid.Column="2" HorizontalTextAlignment="End" FontAttributes="Bold"/>
-                </Grid>
-            </CollectionView.Header>
-            <CollectionView.ItemTemplate>
-                <DataTemplate>
-                    <Grid>
-                        <Grid.ColumnDefinitions>
-                            <ColumnDefinition Width="3*"/>
-                            <ColumnDefinition Width="2*"/>
-                            <ColumnDefinition Width="*"/>
-                        </Grid.ColumnDefinitions>
-                        <Label Grid.Column="0" Text="{Binding Name}"/>
-                        <Label Grid.Column="1" Text="{Binding Stock, StringFormat='{}{0:F0} op voorraad'}" HorizontalOptions="End">
-                            <Label.Triggers>
-                                <DataTrigger TargetType="Label" Binding="{Binding Stock}" Value="0">
-                                    <Setter Property="Text" Value="niet op voorraad" />
-                                </DataTrigger>
-                            </Label.Triggers>
-                        </Label>
-                        <Label Grid.Column="2" Text="{Binding ShelfLife}" HorizontalOptions="End"/>
-                    </Grid>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
+        <VerticalStackLayout Margin="20">
+            <Grid>
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition Width="3*" />
+                    <ColumnDefinition Width="2*" />
+                    <ColumnDefinition Width="*" />
+                    <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
+                <Label Text="Naam van het product" Grid.Column="0" FontAttributes="Bold" />
+                <Label Text="Voorraad" Grid.Column="1" HorizontalTextAlignment="End" FontAttributes="Bold" />
+                <Label Text="THT datum" Grid.Column="2" HorizontalTextAlignment="End" FontAttributes="Bold" />
+                <Label Text="Prijs" Grid.Column="3" HorizontalTextAlignment="End" FontAttributes="Bold" />
+            </Grid>
+
+            <BoxView HeightRequest="1" Color="LightGray" Margin="0,5" />
+
+            <CollectionView ItemsSource="{Binding Products}">
+                <CollectionView.ItemsLayout>
+                    <LinearItemsLayout Orientation="Vertical" ItemSpacing="10" />
+                </CollectionView.ItemsLayout>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="3*" />
+                                <ColumnDefinition Width="2*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Label Grid.Column="0" Text="{Binding Name}" />
+                            <Label Grid.Column="1" Text="{Binding Stock, StringFormat='{}{0:F0} op voorraad'}"
+                                   HorizontalOptions="End">
+                                <Label.Triggers>
+                                    <DataTrigger TargetType="Label" Binding="{Binding Stock}" Value="0">
+                                        <Setter Property="Text" Value="niet op voorraad" />
+                                    </DataTrigger>
+                                </Label.Triggers>
+                            </Label>
+                            <Label Grid.Column="2" Text="{Binding ShelfLife}" HorizontalOptions="End" />
+                            <Label Grid.Column="3" Text="{Binding Price, StringFormat='€ {0:F2}'}"
+                                   HorizontalOptions="End" />
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </VerticalStackLayout>
     </Border>
 </ContentPage>

--- a/Grocery.Core.Data/Repositories/ProductRepository.cs
+++ b/Grocery.Core.Data/Repositories/ProductRepository.cs
@@ -9,10 +9,10 @@ namespace Grocery.Core.Data.Repositories
         public ProductRepository()
         {
             products = [
-                new Product(1, "Melk", 300, new DateOnly(2025, 9, 25)),
-                new Product(2, "Kaas", 100, new DateOnly(2025, 9, 30)),
-                new Product(3, "Brood", 400, new DateOnly(2025, 9, 12)),
-                new Product(4, "Cornflakes", 0, new DateOnly(2025, 12, 31))];
+                new Product(1, "Melk", 300, new DateOnly(2025, 9, 25), 2.00m),
+                new Product(2, "Kaas", 100, new DateOnly(2025, 9, 30), 4.50m),
+                new Product(3, "Brood", 400, new DateOnly(2025, 9, 12), 1.75m),
+                new Product(4, "Cornflakes", 0, new DateOnly(2025, 12, 31), 3.20m)];
         }
         public List<Product> GetAll()
         {

--- a/Grocery.Core/Models/Product.cs
+++ b/Grocery.Core/Models/Product.cs
@@ -7,12 +7,15 @@ namespace Grocery.Core.Models
         [ObservableProperty]
         public int stock;
         public DateOnly ShelfLife { get; set; }
-        public Product(int id, string name, int stock) : this(id, name, stock, default) { }
+        public decimal Price { get; set; }
+        
+        public Product(int id, string name, int stock) : this(id, name, stock, default, default) { }
 
-        public Product(int id, string name, int stock, DateOnly shelfLife) : base(id, name) 
+        public Product(int id, string name, int stock, DateOnly shelfLife, decimal price) : base(id, name) 
         {
             Stock = stock;
             ShelfLife = shelfLife;
+            Price = price;
         }
         public override string? ToString()
         {


### PR DESCRIPTION
This pull request adds support for displaying product prices throughout the grocery app. The main changes include updating the `Product` model to include a `Price` property, adjusting the repository to provide price data, and modifying the product view to show prices in the UI.

**Model and Data Updates:**

* Added a `Price` property to the `Product` model and updated its constructors to support price initialization.
* Updated the `ProductRepository` to initialize products with price values.

**UI Improvements:**

* Modified `ProductView.xaml` to display a new "Prijs" column in both the header and each product row, showing the price formatted as currency. The layout was refactored to use a `VerticalStackLayout` for better structure. Header of table wouldn't align with corresponding columns otherwise.
* Minor formatting and whitespace adjustment at the top of `ProductView.xaml` for clarity.

**Other Changes:**

* Removed custom font registrations from `MauiProgram.cs`. Had to do this due to FontAttributes not working on macOS when the added font in the builder in 'MauiProgram.cs' doesn't support the attribute, like bold text in this case (macOS-specific MAUI bug). So had to do this in order to make the font able to actually display bold.